### PR TITLE
Remove deprecated Gem::Specification#has_rdoc=

### DIFF
--- a/aws-s3.gemspec
+++ b/aws-s3.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
   s.description       = s.summary
   s.email             = 'marcel@vernix.org'
   s.author            = 'Marcel Molina Jr.'
-  s.has_rdoc          = true
   s.extra_rdoc_files  = %w(README COPYING INSTALL)
   s.homepage          = 'http://amazon.rubyforge.org'
   s.rubyforge_project = 'amazon'

--- a/lib/aws/s3/version.rb
+++ b/lib/aws/s3/version.rb
@@ -3,7 +3,7 @@ module AWS
     module VERSION #:nodoc:
       MAJOR    = '0'
       MINOR    = '6'
-      TINY     = '3'
+      TINY     = '4'
       BETA     = nil # Time.now.to_i.to_s
     end
     


### PR DESCRIPTION
[#has_rdoc=](https://www.rubydoc.info/github/rubygems/rubygems/Gem%2FSpecification:has_rdoc) has been deprecated. This minor change lets us remove a spurious warning from sbn's build.

(Ultimately, as sbn's Gemfile [indicates](https://github.com/voxmedia/sbn/blob/422d024812450a401b98f7be3a9d31fabde06596/Gemfile#L44), we hope to replace our use of this gem with `fog`.)